### PR TITLE
added CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "src/fft.c"
+    INCLUDE_DIRS "src"
+)
+


### PR DESCRIPTION
To use this library as a component in my project I had to create this file with assistance from [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#minimal-component-cmakelists). I'm not sure if this is the proper way to include the library as I just did a `git clone` from my project's [directory](https://github.com/adam-puleo/Ferrofluid-Speaker/tree/v0.0.1/ESP32/Ferrofluid-Speaker).